### PR TITLE
Add amazon.co.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ As of the current version, this extension provides support for the following Ama
 
 - [amazon.de](https://www.amazon.de) 
 - [amazon.com](https://www.amazon.com)
+- [amazon.co.uk](https://www.amazon.co.uk)
 
 ## Extension Links
 

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
   "permissions": [ 
     "webRequest",
     "webRequestBlocking",
+    "https://www.amazon.co.uk/*",
     "https://www.amazon.com/*",
     "https://www.amazon.de/*"
   ]

--- a/smile.js
+++ b/smile.js
@@ -17,6 +17,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 	}, 
 
 	{urls : [
+		"https://www.amazon.co.uk/*",
 		"https://www.amazon.com/*",
 		"https://www.amazon.de/*"],
 		


### PR DESCRIPTION
I use the UK version of Amazon, so I wanted to add the UK site to the add-on for automatic redirection.